### PR TITLE
Move card and translation closer to center of page

### DIFF
--- a/src/style/_flashcard.scss
+++ b/src/style/_flashcard.scss
@@ -23,7 +23,7 @@
 
 #translation {
     position: absolute;
-	top: 65%;
+	top: 80%;
 	left: 50%;
 }
 

--- a/src/style/_flashcard.scss
+++ b/src/style/_flashcard.scss
@@ -17,13 +17,13 @@
 #item {
 	position: absolute;
 	font-size: 2em;
-	top: 0%;
+	top: 25%;
 	left: 50%;
 }
 
 #translation {
     position: absolute;
-	top: 80%;
+	top: 65%;
 	left: 50%;
 }
 


### PR DESCRIPTION
Whenever I open a new tab, I almost immediately start typing my next search into the omnibar. Because of this, however, the kana I'm looking at ends up getting covered by my search suggestions:

![image](https://cloud.githubusercontent.com/assets/6826622/25036379/7b895f76-20c1-11e7-92d3-d8f9852ae146.png)

By moving both the card and the translation to the center, we can avoid the kana being covered by the search suggestions.

![image](https://cloud.githubusercontent.com/assets/6826622/25036406/9b73f738-20c1-11e7-9ef7-6737382dac2b.png)
